### PR TITLE
Change npm package name in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Converts .proto files into JSON so they can be [loaded without a parser](https://github.com/dcodeIO/ProtoBuf.js/wiki/Builder#using-json-without-the-proto-parser). For use with [webpack](http://webpack.github.io/docs/) and [ProtoBuf.js](https://github.com/dcodeIO/ProtoBuf.js)
 
 ## Installation
-npm install json-loader
+npm install proto-loader
 
 ## Usage
 


### PR DESCRIPTION
Of course, before #3 is resolved, this still wouldn't make much sense. But neither is the previous one, instructing the user to install _[json-loader](https://www.npmjs.com/package/json-loader)_.
