### PR TITLE
Bug fix allowing diamond dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (source) {
 						return;
 					}
 					loaded[fileName] = true;
-					data.imports[index] = readProto(fs.readFileSync(fileName).toString('utf8'), {}, loaded);
+					data.imports[index] = readProto(fs.readFileSync(fileName).toString('utf8'), options, loaded);
 					return;
 				}
 				throw Error('File not found: ' + imp);

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function (source) {
 						return;
 					}
 					loaded[fileName] = true;
-					data.imports[index] = readProto(fs.readFileSync(fileName).toString('utf8'));
+					data.imports[index] = readProto(fs.readFileSync(fileName).toString('utf8'), {}, loaded);
 					return;
 				}
 				throw Error('File not found: ' + imp);


### PR DESCRIPTION
The current version would fail if a "diamond" dependency existed, for example:
a.proto:
    message A { }
b.proto:
    import "a.proto";
    message B { }
c.proto:
    import "a.proto";
    import "b.proto"; --> ERROR: Duplicate message A defined.

The previous code does have a mechanism to avoid this (the 'loaded' object) but it is not passed down to recursive calls into readProto, which is a bug.
Passing it down fixes the problem.
